### PR TITLE
[Documentation] Changed import ClipboardButton to Clipboard in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ React.render(<MyView/>, document.getElementById('app'));
 Custom HTML tags may be used as well:
 ```javascript
 import React, { Component } from 'react';
-import ClipboardButton from 'react-clipboard.js';
+import Clipboard from 'react-clipboard.js';
 
 class MyView extends Component {
   render() {


### PR DESCRIPTION
Small change but the example code uses `Clipboard` component so we should import Clipboard instead of ClipboardButton 💃 