### PR TITLE
accept more than one component as children too

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ class ClipboardButton extends React.Component {
     component: PropTypes.string,
     children: PropTypes.oneOfType([
       PropTypes.element,
+      PropTypes.arrayOf(PropTypes.element),
       PropTypes.string,
       PropTypes.number,
       PropTypes.object,


### PR DESCRIPTION
so this may work as well without raising any warning:

```jsx
<Clipboard component="div" data-clipboard-text="I'll be copied">
  <i className="my-favorite-icon"></i>
  <span>I'll be copied!</span>
</Clipboard>
```

Currently, if wanna do the same thing above, I'd need an inner `React.Fragment` wrapping my stuff.