### PR TITLE
Remove children from ClipboardButtonProps type

### DIFF
--- a/react-clipboard.d.ts
+++ b/react-clipboard.d.ts
@@ -6,7 +6,6 @@ interface ClipboardButtonProps {
     className?: string;
     style?: React.CSSProperties;
     component?: any;
-    children?: React.ReactChild;
     onClick?: any;
     onSuccess?: (e: ClipboardJS.Event) => void;
     onError?: (e: ClipboardJS.Event) => void;


### PR DESCRIPTION
Inherit the default typing for the children prop from the React.Component type definition instead of replacing it.