### PR TITLE
Component proptype changed to `node`

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ class ClipboardButton extends React.Component {
     type: PropTypes.string,
     className: PropTypes.string,
     style: PropTypes.object,
-    component: PropTypes.string,
+    component: PropTypes.node,
     children: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.arrayOf(PropTypes.element),


### PR DESCRIPTION
I've seen #38 and ran into the same problem.

Currently, passing React Element as `Component` works but raises a warning:
```
Warning: Failed prop type: Invalid prop `component` of type `object` supplied to `ClipboardButton`, expected `string`.
```

This PR makes it work just fine.